### PR TITLE
Attempt to fix url link for final issue

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -103,10 +103,13 @@ steps:
             number: '%payload.repository.pull_request.number%'
           - type: respond
             with: 05_early-close.md
-      - type: respond
-        with: 06a_nice-merge.md
       - type: createIssue
         title: Congratulations!
         body: 06b_final-issue.md
         data:
           url: 'https://%user.username%.github.io/%payload.repository.name%'
+        action_id: finalIssue
+      - type: respond
+        with: 06a_nice-merge.md
+        data:
+          url: '%actions.finalIssue.data.html_url%'


### PR DESCRIPTION
This PR attempts to fix: 
>jonico [< 1 minute ago]
Link pointing to the final issue goes to the same PR where this comment is from, no new PR got created
> ah, index off by one should have pointed me to the list issue, not last PR 

from https://github.com/githubtraining/security/issues/24#issuecomment-427825540