### PR TITLE
Config fixes: update flow so closing isn't necessary, branch protections

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,10 +11,18 @@ before:
     body: 01a_class-introduction-issue.md
 steps:
   - title: Enable security settings
-    description: After you enable GitHub Security features in your repository, close this issue.
-    event: issues.closed
+    description: Enable GitHub Security features and GitHub Pages in your repository
+    event: deployment_status
     link: '{{ repoUrl }}/issues/1'
     actions:
+      - type: gate
+        left: '%payload.deployment_status.state%'
+        operator: ===
+        right: success
+      - type: gate
+        left: '%payload.deployment.environment%'
+        operator: ===
+        right: github-pages
       - type: createIssue
         title: Find repository vulnerabilities
         body: 02_find-vulnerabilities.md
@@ -24,6 +32,8 @@ steps:
         data:
           url: '%actions.issue.data.html_url%'
           pages: 'https://%user.username%.github.io/%payload.repository.name%'
+      - type: closeIssue
+        issue: Welcome
 
   - title: Find the vulnerable dependency
     description: Find the vulnerable dependency, and comment with the suggested update version.

--- a/responses/01a_class-introduction-issue.md
+++ b/responses/01a_class-introduction-issue.md
@@ -23,7 +23,6 @@ For this course, you'll need to know how to create a branch on GitHub, commit ch
 1. Scroll down until you see **Data services**.
 1. Under **Data services**, click the check boxes to enable all of the data services.
 1. Scroll down to **GitHub Pages**. Select `master` as a **Source**, and click **Save**.
-1. Close this issue.
 
 For a printable version of the steps in this course, check out the [Quick Reference Guide]({{ host }}/public/{{ course.slug }}.pdf).
 


### PR DESCRIPTION
This pull request: 
- Resolves #48 brought up by @hectorsector by having the first event enabling GH pages, and then the bot closes instead of the user (also relates to @beardofedu's feedback)  
- Resolves #51 by enabling branch protections before the 2nd PR. Hopefully will also make #45 right, but that's still to be seen.