### PR TITLE
Update instructions for skipping steps

### DIFF
--- a/responses/01a_class-introduction-issue.md
+++ b/responses/01a_class-introduction-issue.md
@@ -17,7 +17,7 @@ For this course, you'll need to know how to create a branch on GitHub, commit ch
 
 ### :keyboard: Activity: Enable Vulnerability alerts & GitHub Pages
 
-**Is your repository public?** If so, skip below to **step 4**. These features are enabled by default on public repositories. If this is a **private repository**, continue with the instructions here.
+**Is your repository public?** If so, only complete **step 1** and **step 4**. These features are enabled by default on public repositories. If this is a **private repository**, continue with the instructions here.
 
 1. Click the **Settings** tab in your repository.
 1. Scroll down until you see **Data services**.


### PR DESCRIPTION
This fixes #72 by making sure instructions for skipping steps are accurate. This isn't an ideal solution, and it would be much better if we could make #52 work. 