### PR TITLE
Add steps for removing app

### DIFF
--- a/responses/06b_final-issue.md
+++ b/responses/06b_final-issue.md
@@ -2,20 +2,23 @@
 
 ![celebrate](https://octodex.github.com/images/benevocats.jpg)
 
-Congratulations @{{ user.username }}, you've completed this course! But, a good thing to do now is uninstall this app from your repository.
+Congratulations @{{ user.username }}, you've completed this course! But, a good thing to do now is limit this app's permissions.
 
 When considering the security of your repository, consider the installed applications, like me. But from a security perspective, each of these apps has access to some of your data. Every so often, check the apps and integrations that have access to your repositories. Look for things like active use, or  permissions giving more access than necessary.
 
-As much as it pains me to leave you, I want you to uninstall me. I won't be able to congratulate you on achieving this task, but know I'm excited about your progress.
+As much as it pains me to leave you, I want you to uninstall me on some of your repositories. I might not be able to congratulate you on achieving this task, but know I'm excited about your progress.
 
 
-### :keyboard: Activity: Remove this app
+### :keyboard: Activity: Restrict this app
 1. Click on the **Settings** tab in your repository
-2. On the left hand side, click **Integrations & services**
-3. Find **Learning Lab**, and click **Configure**
-4. Enter your password if prompted
-5. Choose the repository access that you'd like to keep
+1. On the left hand side, click **Integrations & services**
+1. Find **Learning Lab**, and click **Configure**
+1. Enter your password if prompted
+1. Choose the repository access that you'd like to keep
   - _Note: If you'd like to take more Learning Lab courses in the future, **do not** uninstall Learning Lab. If you uninstall Learning Lab, you'll need to reinstall the app when you try another course. You may also lose some progress._
+1. To make taking Learning Lab courses easier in the future, click **Only select repositories**
+1. Select a repository that you have completed with Learning Lab, like this one
+1. Click **Save**
 
 ### What went well
 


### PR DESCRIPTION
This PR resolves #82 by adding instructions for removing Learning Lab. 

This is only an instructional change, and doesn't add any events to watch for, as it won't work anyway. 😛 

@JasonEtco [confirmed via Slack](https://github.slack.com/archives/C0F4LK0KX/p1539234150000100) that this won't screw up stats for the course. The instructions are also suggesting that a user doesn't uninstall completely, but that leaves the instructions a bit confusing. Not sure what to edit here but it doesn't feel done yet. 🤔 Any input is welcome @githubtraining/trainers  (cc @beardofedu because of ✨ help with other wording on this earlier)