### PR TITLE
Update page build trigger

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -31,7 +31,7 @@ before:
 steps:
   - title: Enable repository settings
     description: Enable settings in your repository for the next activities.
-    event: deployment
+    event: page_build
     link: '{{ repoUrl }}/issues/2'
     actions:
       - type: createIssue


### PR DESCRIPTION
This pull request should fix the course on enterprise, and we need to test to confirm that it will also work on .com. This relates to the event for user enabling pages.

cc @githubtraining/learning-engineering @githubtraining/trainers 