### PR TITLE
Update instructions for configuring a GitHub Pages source

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Every Learning Lab course is made up of:
 
 The course repository is written in YAML and Markdown. The template repository could be written in any language that supports the learning objectives.
 
-For more information on the goals of this course, check out the [`course-details.md`](course-details.md). 
+For more information on the goals of this course, check out the [`course-details.md`](course-details.md).
 
 ## Contribute
 

--- a/responses/01a_class-introduction-issue.md
+++ b/responses/01a_class-introduction-issue.md
@@ -28,7 +28,7 @@ This project is centered around a memory game that will be deployed with GitHub 
 1. Click the [**Settings**]({{ repoUrl }}/settings) tab in your repository.
 1. Scroll down until you see **Data services**.
 1. Under **Data services**, click the check boxes to enable all the data services.
-1. Scroll down to **GitHub Pages** and select **master branch** as a **Source**.
+1. Scroll down to **GitHub Pages** and select `master` as a **Source**.
 
 {% else %}
 
@@ -36,7 +36,7 @@ This project is centered around a memory game that will be deployed with GitHub 
 
 
 1. Click the [**Settings**]({{ repoUrl }}/settings) tab in your repository.
-1. Scroll down to **GitHub Pages** and select **master branch** as a **Source**.
+1. Scroll down to **GitHub Pages** and select `master` as a **Source**.
 
 {% endif %}
 

--- a/responses/01a_class-introduction-issue.md
+++ b/responses/01a_class-introduction-issue.md
@@ -28,7 +28,7 @@ This project is centered around a memory game that will be deployed with GitHub 
 1. Click the [**Settings**]({{ repoUrl }}/settings) tab in your repository.
 1. Scroll down until you see **Data services**.
 1. Under **Data services**, click the check boxes to enable all the data services.
-1. Scroll down to **GitHub Pages**. Select `master` as a **Source**, and click **Save**.
+1. Scroll down to **GitHub Pages** and select **master branch** as a **Source**.
 
 {% else %}
 
@@ -36,7 +36,7 @@ This project is centered around a memory game that will be deployed with GitHub 
 
 
 1. Click the [**Settings**]({{ repoUrl }}/settings) tab in your repository.
-1. Scroll down to **GitHub Pages**. Select `master` as a **Source**, and click **Save**.
+1. Scroll down to **GitHub Pages** and select **master branch** as a **Source**.
 
 {% endif %}
 


### PR DESCRIPTION
Changes are now saved immediately after selecting a publishing source.

Official docs for reference: [Configuring a publishing source for your GitHub Pages site](https://help.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site).